### PR TITLE
Support `short_name` alongside `UUID` in POST and PUT Endpoints

### DIFF
--- a/api/review/views.py
+++ b/api/review/views.py
@@ -77,26 +77,46 @@ class ReviewAPIView(views.APIView):
                     "data": serializer.data}
         return Response(data=response, status=status.HTTP_200_OK)
 
+
     def put(self, request, review_id=None):
         try:
             review_object = Review.objects.get(id=review_id)
             data = request.data
-            serializer = self.serializer_class(
-                data=data, instance=review_object)
+
+            school_identifier = data.get('school', None)
+            if school_identifier:
+                try:
+                    # Checking if valid UUID is provided
+                    if uuid.UUID(school_identifier):
+                        school = School.objects.get(pk=school_identifier)
+                except (ValueError, School.DoesNotExist):
+                    # Getting school from short_name if UUID is not valid
+                    school = School.objects.filter(short_name=school_identifier).first()
+                    if not school:
+                        # Error response if no school object is found with the short_name or UUID
+                        return Response(
+                            {"error": "School not found with the provided identifier."},
+                            status=status.HTTP_404_NOT_FOUND
+                        )
+
+                data['school'] = school.pk
+
+            serializer = self.serializer_class(review_object, data=data)
             if serializer.is_valid():
                 serializer.save()
-                response = {
+                return Response({
                     "message": "Review updated successfully",
-                    "data": serializer.data,
-                }
-                return Response(data=response, status=status.HTTP_200_OK)
+                    "data": serializer.data
+                }, status=status.HTTP_200_OK)
 
-            return Response(data=serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
         except Review.DoesNotExist:
             return Response(
-                {"message": "Review not found!", "data": []},
-                status=status.HTTP_404_NOT_FOUND,
+                {"message": "Review not found!"},
+                status=status.HTTP_404_NOT_FOUND
             )
+
 
     def delete(self, request, *args, **kwargs):
         review_id = kwargs.get('review_id')

--- a/api/review/views.py
+++ b/api/review/views.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from review.models import Review
 from school.models import School
 from review.serializers import ReviewSerializer
+import uuid
 
 
 class ReviewAPIView(views.APIView):
@@ -14,6 +15,25 @@ class ReviewAPIView(views.APIView):
 
     def post(self, request):
         data = request.data
+
+        school_identifier = data.get('school', None)
+        if school_identifier:
+            try:
+                # Checking if valid UUID is provided
+                if uuid.UUID(school_identifier):
+                    school = School.objects.get(pk=school_identifier)
+            except (ValueError, School.DoesNotExist):
+                # Getting school from short_name if UUID is not valid.
+                school = School.objects.filter(short_name=school_identifier).first()
+                if not school:
+                    # Error response if no school object is found with the short_name or UUID
+                    return Response(
+                        {"error": "School not found with the provided identifier."},
+                        status=status.HTTP_404_NOT_FOUND
+                    )
+
+            data['school'] = school.pk
+
         serializer = self.serializer_class(data=data)
         if serializer.is_valid():
             serializer.save()


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
- Enhances `Review` endpoints by allowing the use of a school's `short_name` alongside `UUID` for POST and PUT operations.
- Implemented input validation for `short_name` 
- Implemented input validation for `UUID`.

**_WHAT ISSUES ARE RELATED TO THIS PR?_**
  - [X] #75 

**_HOW DO I TEST OUT THIS PR?_**
Run this project locally and test the following endpoints:
Base URL: `http://localhost:8000/api/v1`.
To test the endpoints, go to `http://localhost:8000/api/v1/reviews/` - Use django restframework UI to try out the endpoints
### Testing Endpoints:
- **Create a new review with `short_name`**:
`POST /reviews/`
Send a JSON payload with the new review details using short_name. Example request body:
```json
{
  "school": "UNLV",
  "review_text": "This is a review.",
  "term": "Spring",
  "grade_received": "A-",
  "delivery_method": "Hybrid",
  "helpful_count": 3
}
```
- **Update a review with `short_name`**:
`PUT /reviews/{review_id}/`
Replace {review_id} with the `UUID` of the review to update. Send a JSON payload including the short_name to reference the school. Example request body:
```json
{
  "school": "UNLV",
  "review_text": "This is an edited review.",
  "term": "Fall",
  "grade_received": "A-",
  "delivery_method": "Hybrid",
  "helpful_count": 3
}
```

**Note:** The endpoints will reject requests if either `short_name` or `UUID` are missing or invalid. Ensure that you use the correct `short_name` or `UUID` that corresponds to an existing school in the database.

ADDITIONAL INFORMATION

- [x] Pipeline passing
- [x] Unit tests added for new functionality
- [x] Code coverage remains at 100%
- [x] Changes tested locally and endpoints verified