### PR TITLE
Home page mobile responsiveness

### DIFF
--- a/web/src/pages/Home.jsx
+++ b/web/src/pages/Home.jsx
@@ -1,5 +1,5 @@
-import Searchbar from "../components/Searchbar";
-import QA from "../components/QA";
+import Searchbar from "../components/Searchbar"
+import QA from "../components/QA"
 
 const Home = () => {
   return (

--- a/web/src/pages/Home.jsx
+++ b/web/src/pages/Home.jsx
@@ -12,18 +12,18 @@ const Home = () => {
         <Searchbar
           searchingSchools={true}
           searchingCourses={false}
-          className="w-full"
+          className="w-full px-4 truncate"
           searchPlaceholder="Ex: University of Nevada, Las Vegas / UNLV"
         />
       </div>
 
       {/* Bottom of page: FAQ section */}
-      <div className="w-full justify-center mx-auto mb-12">
+      <div className="w-full justify-center mx-auto mb-12 pt-4">
         <h1 className="sm:text-md md:text-l l:text-xl xl:text-2xl text-center no-underline text-grey-darkest hover:text-blue-dark mb-8 font-semibold">
           Frequently Asked Questions
         </h1>
         {/* Question/Answer Components */}
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 px-4">
           <QA
             question="Why are evaluations important?"
             answer="Evaluations provide a detailed review of a course that covers

--- a/web/src/pages/Home.jsx
+++ b/web/src/pages/Home.jsx
@@ -1,5 +1,5 @@
-import Searchbar from '../components/Searchbar';
-import QA from '../components/QA';
+import Searchbar from "../components/Searchbar";
+import QA from "../components/QA";
 
 const Home = () => {
   return (

--- a/web/src/pages/Home.jsx
+++ b/web/src/pages/Home.jsx
@@ -3,7 +3,7 @@ import QA from '../components/QA';
 
 const Home = () => {
   return (
-    <div className="flex flex-col justify-evenly h-[calc(100vh-94px)] max-w-screen-xl mx-auto">
+    <div className="overflow-auto flex flex-col justify-evenly h-[calc(100vh-94px)] max-w-screen-xl mx-auto">
       {/* Search bar */}
       <div className="flex-1 flex flex-col w-full justify-center items-center gap-4">
         <p className="sm:text-lg md:text-xl l:text-2xl xl:text-3xl font-bold text-center mx-14">

--- a/web/src/pages/Home.jsx
+++ b/web/src/pages/Home.jsx
@@ -1,12 +1,12 @@
-import Searchbar from "../components/Searchbar"
-import QA from "../components/QA"
+import Searchbar from '../components/Searchbar';
+import QA from '../components/QA';
 
 const Home = () => {
   return (
     <div className="flex flex-col justify-evenly h-[calc(100vh-94px)] max-w-screen-xl mx-auto">
       {/* Search bar */}
-      <div className="flex-1 flex flex-col w-full justify-center items-center gap-4 ">
-        <p className="text-3xl font-bold">
+      <div className="flex-1 flex flex-col w-full justify-center items-center gap-4">
+        <p className="sm:text-lg md:text-xl l:text-2xl xl:text-3xl font-bold text-center mx-14">
           Find your school below to leave an evaluation!
         </p>
         <Searchbar
@@ -19,7 +19,7 @@ const Home = () => {
 
       {/* Bottom of page: FAQ section */}
       <div className="w-full justify-center mx-auto mb-12">
-        <h1 className="text-center text-2xl no-underline text-grey-darkest hover:text-blue-dark mb-8 font-semibold">
+        <h1 className="sm:text-md md:text-l l:text-xl xl:text-2xl text-center no-underline text-grey-darkest hover:text-blue-dark mb-8 font-semibold">
           Frequently Asked Questions
         </h1>
         {/* Question/Answer Components */}


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

  - The Home page now has basic mobile responsiveness (mainly text scaling and appropriate element padding)
    - Text scaling could easily be "relaxed" and larger font sizes can be reintroduced if desired

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

  - #104 

**_HOW DO I TEST OUT THIS PR?_**

  - Run this project's front end locally (navigate to the `web` directory, run `npm i`, then `npm run dev`)
  - The "Home" page should appear
  - To test the mobile version in your browser, use "inspect element"
    - Current home page:
![image](https://github.com/chrisj117/CS-472-GROUP-2-PROJECT/assets/35480893/64db7f6e-7b60-4ea4-b782-091b51a0fbbe)
    - New home page, rendering at 399x844 (iPhone 12/13 dimensions):
![image](https://github.com/chrisj117/CS-472-GROUP-2-PROJECT/assets/35480893/c22ef409-60e0-4056-81f6-1cf4ac0f846b)

