### PR TITLE
Request School page mobile responsiveness

### DIFF
--- a/web/src/pages/RequestSchool.jsx
+++ b/web/src/pages/RequestSchool.jsx
@@ -4,18 +4,18 @@ import { BsFillEnvelopePaperFill } from "react-icons/bs"
 const RequestSchool = () => {
   return (
     <div className="max-w-screen-xl mx-auto flex flex-col items-center h-[calc(100vh-94px)]">
-      <h2 className="text-3xl font-bold mb-12 mt-8">Request School</h2>
+      <h2 className="sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold mb-12 mt-8">Request School</h2>
       <div className="w-full flex flex-col items-center gap-4">
         {/* Check if your school is already here */}
         <div className="mb-4 flex flex-col w-full">
-          <p className="mb-4 text-xl text-center">
+          <p className="sm:text-base md:text-base lg:text-xl xl:text-2xl mb-4 text-center">
             <span className="font-bold text-blue-600">Wait!</span> Check if your
             school is already here:
           </p>
           <Searchbar
             searchingSchools={true}
             searchPlaceholder="Ex: University of Nevada, Las Vegas / UNLV"
-            className="w-full mb-8"
+            className="w-full mb-8 truncate"
           />
         </div>
         {/* Request a School Form */}
@@ -23,27 +23,29 @@ const RequestSchool = () => {
 
         <div className="flex flex-col gap-3 w-full">
           <div className="mb-4">
-            <p className="mb-4 text-center text-xl">
+            <p className="sm:text-base md:text-lg lg:text-xl xl:text-2xl mb-4 text-center">
               If you can&apos;t find your institution above, submit your
               school&apos;s information below!
             </p>
-            <label className="flex flex-col gap-1 text-lg">
+            <label className="flex flex-col gap-1 sm:text-sm md:text-base lg:text-lg">
               Enter School Name
               <input
                 type="text"
                 placeholder="Ex: University of Nevada Las Vegas"
-                className="px-4 py-2 w-full border-2 rounded"
+                className="p-2 w-full border-2 rounded truncate"
               />
             </label>
           </div>
 
           <div className="mb-4">
-            <label className="block mb-2">Enter School Website</label>
+            <label className="flex flex-col gap-1 sm:text-sm md:text-base lg:text-lg">
+            Enter School Website
             <input
               type="text"
               placeholder="Ex: https://www.unlv.edu/"
-              className="p-2 w-full border-2 rounded"
+              className="p-2 w-full border-2 rounded truncate"
             />
+            </label>
           </div>
         </div>
 

--- a/web/src/pages/RequestSchool.jsx
+++ b/web/src/pages/RequestSchool.jsx
@@ -3,19 +3,19 @@ import { BsFillEnvelopePaperFill } from "react-icons/bs"
 
 const RequestSchool = () => {
   return (
-    <div className="max-w-screen-xl mx-auto flex flex-col items-center h-[calc(100vh-94px)]">
-      <h2 className="sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold mb-12 mt-8">Request School</h2>
+    <div className="overflow-auto max-w-screen-xl mx-auto flex flex-col items-center h-[calc(100vh-94px)]">
+      <h2 className="text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold mb-12 mt-8">Request School</h2>
       <div className="w-full flex flex-col items-center gap-4">
         {/* Check if your school is already here */}
         <div className="mb-4 flex flex-col w-full">
-          <p className="sm:text-base md:text-base lg:text-xl xl:text-2xl mb-4 text-center">
+          <p className="text-base md:text-lg lg:text-xl xl:text-2xl mb-4 text-center">
             <span className="font-bold text-blue-600">Wait!</span> Check if your
             school is already here:
           </p>
           <Searchbar
             searchingSchools={true}
             searchPlaceholder="Ex: University of Nevada, Las Vegas / UNLV"
-            className="w-full mb-8 truncate"
+            className="w-full mb-8 truncate px-4 text-sm md:text-base lg:text-lg"
           />
         </div>
         {/* Request a School Form */}
@@ -23,11 +23,11 @@ const RequestSchool = () => {
 
         <div className="flex flex-col gap-3 w-full">
           <div className="mb-4">
-            <p className="sm:text-base md:text-lg lg:text-xl xl:text-2xl mb-4 text-center">
+            <p className="text-base md:text-lg lg:text-xl xl:text-2xl mb-4 text-center">
               If you can&apos;t find your institution above, submit your
               school&apos;s information below!
             </p>
-            <label className="flex flex-col gap-1 sm:text-sm md:text-base lg:text-lg">
+            <label className="flex flex-col gap-1 text-sm md:text-base lg:text-lg px-4">
               Enter School Name
               <input
                 type="text"
@@ -38,7 +38,7 @@ const RequestSchool = () => {
           </div>
 
           <div className="mb-4">
-            <label className="flex flex-col gap-1 sm:text-sm md:text-base lg:text-lg">
+            <label className="flex flex-col gap-1 text-sm md:text-base lg:text-lg px-4">
             Enter School Website
             <input
               type="text"


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

  - The Request School page now has basic mobile responsiveness (mainly text scaling and appropriate element padding)
    - Compared to #123 , this PR also attempts to follow 3 levels of font sizes:
      - 1: For main headers `text-lg md:text-xl lg:text-2xl xl:text-3xl`
      - 2: For sub headers `text-base md:text-lg lg:text-xl xl:text-2xl`
      - 3: For input box example text and labels `text-sm md:text-base lg:text-lg`
  - Small refactoring done to the Enter School Name and Enter School Website boxes

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

  - #106 

**_HOW DO I TEST OUT THIS PR?_**

  - Run this project's front end locally (navigate to the `web` directory, run `npm i`, then `npm run dev`)
  - Navigate to the "Request School" page (use the navbar or go to http://localhost:5173/request-school)
  - To test the mobile version in your browser, use "inspect element" (both examples are rendering at iPhone 12/13 dimensions of 399x844)
    - Current request school page:
![Screenshot 2023-11-30 at 16-59-58 Vite React](https://github.com/chrisj117/CS-472-GROUP-2-PROJECT/assets/35480893/f9fce1a4-05c7-433d-9dd8-427957ceba28)
    - Updated request school page:
![image](https://github.com/chrisj117/CS-472-GROUP-2-PROJECT/assets/35480893/3bdc4c5a-4b32-43eb-b79b-ee11b800bd15)

