### PR TITLE
Updated Login.jsx to fix mobile dark mode

### DIFF
--- a/web/src/pages/Login.jsx
+++ b/web/src/pages/Login.jsx
@@ -80,7 +80,7 @@ const Login = () => {
   return (
     <form
       onSubmit={handleLogin}
-      className="max-w-screen-xl mx-auto flex flex-col items-center h-[calc(100vh-98px)]"
+      className="overflow-auto max-w-screen-xl mx-auto flex flex-col items-center h-[calc(100vh-98px)]"
     >
       {/* Login Page Heading */}
       <h2 className="text-3xl font-bold mb-12 mt-8">Login</h2>


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

  - Fixes the white cutoff on the horizontal mobile login page in dark mode

**_WHAT ISSUES ARE RELATED TO THIS PR?_**

  - #147 

**_HOW DO I TEST OUT THIS PR?_**

  - cd to web directory
  - run the command 'npm run dev'
  - go to the website
  - go to the login page in dark mode
  - use inspect element and toggle device toolbar to iPhone 12 Pro dimensions
  - switch to the horizontal dimensions
  - you should see that the white cutoff is no longer there
