### PR TITLE
Hotfix: Update Input Styles in Dark Mode

### DIFF
--- a/web/src/components/InputField.jsx
+++ b/web/src/components/InputField.jsx
@@ -16,7 +16,7 @@ const InputField = ({
             type={inputType}
             id={inputID}
             placeholder={inputPlaceholder}
-            className="px-4 py-2 w-full border-2 rounded dark:text-black"
+            className="px-3 py-2 w-full border-2 rounded truncate dark:bg-zinc-900 dark:border-zinc-600 dark:text-white focus:outline-transparent"
             onChange={onChange}
           />
         </label>

--- a/web/src/pages/Profile.jsx
+++ b/web/src/pages/Profile.jsx
@@ -39,7 +39,7 @@ const Profile = () => {
   }
 
   return (
-    <section className="flex flex-col items-center min-h-[calc(100vh-98px)] w-screen max-w-screen-xl mx-auto">
+    <section className="flex flex-col items-center min-h-[calc(100vh-98px)] w-screen max-w-screen-xl mx-auto px-4">
       <h2 className="text-3xl font-bold mb-12 mt-8">Profile</h2>
 
       <div className="flex flex-col gap-2 items-center">


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

  - Fixes the input dark mode colors on login/registration
  - Update profile margin on mobile screen
  
**_WHAT ISSUES ARE RELATED TO THIS PR?_**

  - #98 

**_HOW DO I TEST OUT THIS PR?_**

  - Goto `web` directory and run `npm i` then `npm run dev` and go to the login or registration page. The input fields should look different when dark mode is enabled.
