### PR TITLE
Updated Review.jsx mobile vertical dark mode

### DIFF
--- a/web/src/pages/Review.jsx
+++ b/web/src/pages/Review.jsx
@@ -15,7 +15,7 @@ const Review = () => {
   const { user } = useAuth()
 
   return (
-    <div className="max-w-screen-xl mx-auto mt-8 flex flex-col min-h-[calc(100vh-98px)]">
+    <div className="overflow-auto max-w-screen-xl mx-auto mt-8 flex flex-col min-h-[calc(100vh-98px)]">
       {/* Top of screen (below nav bar) */}
       <div className="flex flex-col gap-4 mb-8 border-b-2 border-zinc-200 dark:border-zinc-600 pb-10">
         <h2 className="font-bold text-3xl">


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**

  - Fixes the white cutoff on the review page in the vertical iPhone 12 Pro dimensions in dark mode
  
**_WHAT ISSUES ARE RELATED TO THIS PR?_**

  - #156 

**_HOW DO I TEST OUT THIS PR?_**

  - cd to web directory and run locally by doing 'npm run dev'
  - go to the website and add '/review' to the end of the url to see the review page
  - use inspect element and use 'toggle device toolbar' to switch to iPhone 12 Pro dimensions
  - you should see that there is no white cutoff